### PR TITLE
Update Cargo.lock by running cargo build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "rsblocks"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "alsa",
  "async-std",


### PR DESCRIPTION
It's a good practice to make sure after someone is building the project no git changes will be made. I'm also trying to add rsblocks into the nixpkgs package repository, and it requires a clean Cargo.lock file.